### PR TITLE
Added 'memory' library

### DIFF
--- a/tests/CTPP2Emulator.cpp
+++ b/tests/CTPP2Emulator.cpp
@@ -40,7 +40,7 @@
 #include <CTPP2VMSTDLib.hpp>
 #include <CTPP2VMStackException.hpp>
 #include <CTPP2GetText.hpp>
-
+#include <memory>
 #include <sys/stat.h>
 
 #ifdef HAVE_SYS_TIME_H


### PR DESCRIPTION
When compiling it throws the following error:

 'auto_ptr' is not a member of 'std'

It gets fixed by adding the memory library. I compiled it on Raspberry Pi 3, running Rasbpian 9 (Stretch).

Here they had the same problem:
https://github.com/Woodya/node-gzbz2/issues/4
