### PR TITLE
Added 'unistd.h' library

### DIFF
--- a/src/CTPP2FileSourceLoader.cpp
+++ b/src/CTPP2FileSourceLoader.cpp
@@ -33,7 +33,7 @@
 #include "CTPP2FileSourceLoader.hpp"
 
 #include "CTPP2Exception.hpp"
-
+#include <unistd.h>
 #include <sys/stat.h>
 #include <errno.h>
 #include <stdio.h>


### PR DESCRIPTION
When compiling with 'make', it used to give the following error:

ctpp2-2.7.1/src/CTPP2FileSourceLoader.cpp:219:34: error: ‘getcwd’ was not declared in this scope
     CHAR_P szPWD = getcwd(NULL, 0);
                                  ^
CMakeFiles/ctpp2.dir/build.make:238: recipe for target 'CMakeFiles/ctpp2.dir/src/CTPP2FileSourceLoader.cpp.o' failed
make[2]: *** [CMakeFiles/ctpp2.dir/src/CTPP2FileSourceLoader.cpp.o] Error 1
CMakeFiles/Makefile2:375: recipe for target 'CMakeFiles/ctpp2.dir/all' failed
make[1]: *** [CMakeFiles/ctpp2.dir/all] Error 2
Makefile:127: recipe for target 'all' failed
make: *** [all] Error 2

It gets fixed by adding that mentioned library. My device is a Raspberry Pi 3 running Raspbian 9 (Stretch)

They fixed it here by adding that library:
https://github.com/moneymanagerex/ctpp/issues/2